### PR TITLE
Make `WebDriverBiDiSession` cloneable

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -66,6 +66,7 @@ pub type EventHandler =
 /// * `websocket_stream` - The WebSocket stream for communication protected by an `Arc` wrapped `Mutex`.
 /// * `pending_commands` - A map of pending commands awaiting responses protected by an `Arc` wrapped `Mutex`.
 /// * `event_handlers` - A map of events and their handlers protected by an `Arc` wrapped `Mutex`.
+#[derive(Clone)]
 pub struct WebDriverBiDiSession {
     pub host: String,
     pub port: u16,

--- a/src/webdriver/capabilities.rs
+++ b/src/webdriver/capabilities.rs
@@ -14,7 +14,7 @@ use serde_json::{json, Value};
 pub type Extensible = HashMap<String, Value>;
 
 /// Standard WebDriver capabilities https://w3c.github.io/webdriver/#capabilities.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct CapabilityRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -77,7 +77,7 @@ impl CapabilityRequest {
 // --------------------------------------------------
 
 /// Capabilities struct to represent the standard capabilities JSON object.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CapabilitiesRequest {
     #[serde(rename = "alwaysMatch", skip_serializing_if = "Option::is_none")]
     always_match: Option<CapabilityRequest>,


### PR DESCRIPTION
To my understanding it should be possible to use multiple different user/browsing context concurrently and this should be the simplest way to support this for now.